### PR TITLE
When in iframe mode, rely on textarea value for initial editor content

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -102,9 +102,11 @@ export class Editor extends React.Component<IAllProps> {
   };
 
   private initEditor(initEvent: Event, editor: any) {
-    const value =
-      typeof this.props.value === 'string' ? this.props.value : typeof this.props.initialValue === 'string' ? this.props.initialValue : '';
-    editor.setContent(value);
+    if (!this.inline) {
+      const value =
+        typeof this.props.value === 'string' ? this.props.value : typeof this.props.initialValue === 'string' ? this.props.initialValue : '';
+      editor.setContent(value);
+    }
 
     if (isFunction(this.props.onEditorChange)) {
       editor.on('change keyup setcontent', (e: any) => {
@@ -128,6 +130,8 @@ export class Editor extends React.Component<IAllProps> {
   }
 
   private renderIframe() {
-    return <textarea ref={(elm) => (this.element = elm)} style={{ visibility: 'hidden' }} id={this.id} />;
+    const value =
+      typeof this.props.value === 'string' ? this.props.value : typeof this.props.initialValue === 'string' ? this.props.initialValue : '';
+    return <textarea ref={(elm) => (this.element = elm)} style={{ visibility: 'hidden' }} id={this.id} value={value} />;
   }
 }


### PR DESCRIPTION
When relying on `setContent` in `init`, there's an occasional tiny delay. By making the textarea the source of the initial value, there is no delay.