### PR TITLE
Get textareaName onEditorChange

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -121,7 +121,7 @@ export class Editor extends React.Component<IAllProps> {
       editor.on('change keyup setcontent', (e: any) => {
         this.currentContent = editor.getContent();
         if (isFunction(this.props.onEditorChange)) {
-          this.props.onEditorChange(this.currentContent);
+          this.props.onEditorChange(this.currentContent, this.props.textareaName);
         }
       });
     }


### PR DESCRIPTION
I am using the editor inside a form repeater component. This allows me to create / remove as many editors as I need in that form. Each editor will have a different `textareaName`. I need to update the state of my component, `onEditorChange`, from any of my editors. However, currently I have no way of knowing which editor is calling `onEditorChange` since they all route to the same method in my component. This change allows a second parameter in `onEditorChange` - the `textareaName` of the editor that is calling the method. I can then know which editor has called `onEditorChange` so that I can update my component state with the correct value accordingly.