### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-react",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Official TinyMCE React Component",
   "repository": {
     "url": "https://github.com/tinymce/tinymce-react"


### PR DESCRIPTION
Hello, I'd like to bump the version to 3.4.0 so that I could use the changes brought in by this commit https://github.com/tinymce/tinymce-react/commit/3fef7b7c29abcb34ac64ffdd8d4e1c3f88bace1e. I'm trying to use the getCharacterCount API, which is not available in tinymce version 5.0.4.