### PR TITLE
Always load from CDN if apiKey is set

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -72,7 +72,7 @@ export class Editor extends React.Component<IAllProps> {
   }
 
   public componentDidMount() {
-    if (getTinymce() !== null) {
+    if (!this.props.apiKey && getTinymce() !== null) {
       this.initialise();
     } else if (this.elementRef.current && this.elementRef.current.ownerDocument) {
       ScriptLoader.load(


### PR DESCRIPTION
Since there's no way to use both self-hosted TMC and apiKey, yhis allows apps to provide a locally-loaded fallback using `import` while still fetching from individual users' Tiny Cloud instances when desired.