### PR TITLE
Unbind SaveContent event when component is unmounted

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -85,6 +85,9 @@ export class Editor extends React.Component<IAllProps> {
 
   public componentWillUnmount() {
     if (getTinymce() !== null) {
+      if (this.editor) {
+        this.editor.off('SaveContent');
+      }
       getTinymce().remove(this.editor);
     }
   }


### PR DESCRIPTION
Prevents the `onSaveContent` function from being fired when the component unmounts.

resolves #114 