### PR TITLE
Timeout and script attr props added to the script loader

### DIFF
--- a/src/main/ts/ScriptLoader.ts
+++ b/src/main/ts/ScriptLoader.ts
@@ -33,14 +33,14 @@ const CreateScriptLoader = (): ScriptLoader => {
   let state: IStateObj = createState();
 
   const injectScriptTag = (scriptId: string, doc: Document, url: string, callback: callbackFn, scriptAttributes?: IProps['scriptAttributes']) => {
-    const scriptTag = doc.createElement('script');
+    let scriptTag = doc.createElement('script');
     scriptTag.referrerPolicy = 'origin';
     scriptTag.type = 'application/javascript';
     scriptTag.id = scriptId;
     scriptTag.src = url;
 
     if (scriptAttributes)
-      scriptAttributes = { ...scriptAttributes, ...scriptAttributes }
+      scriptTag = { ...scriptTag, ...scriptAttributes }
 
     const handler = () => {
       scriptTag.removeEventListener('load', handler);

--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -29,9 +29,18 @@ export interface IProps {
   disabled: boolean;
   textareaName: string;
   tinymceScriptSrc: string;
+  /**
+   * A timeout for loading the script to let the other scripts 
+   * load first if the editor is not the main content of the page.
+   */
+  loadTimeOut?: number;
+
+  // 
+  scriptAttributes?: Pick<HTMLScriptElement, 'async' | 'defer'>;
+
 }
 
-export interface IAllProps extends Partial<IProps>, Partial<IEvents> {}
+export interface IAllProps extends Partial<IProps>, Partial<IEvents> { }
 
 export class Editor extends React.Component<IAllProps> {
   public static propTypes: IEditorPropTypes = EditorPropTypes;
@@ -47,7 +56,7 @@ export class Editor extends React.Component<IAllProps> {
   private currentContent?: string | null;
   private boundHandlers: Record<string, EventHandler<any>>;
 
-  constructor (props: Partial<IAllProps>) {
+  constructor(props: Partial<IAllProps>) {
     super(props);
     this.id = this.props.id || uuid('tiny-react');
     this.elementRef = React.createRef<Element>();
@@ -55,7 +64,7 @@ export class Editor extends React.Component<IAllProps> {
     this.boundHandlers = {};
   }
 
-  public componentDidUpdate (prevProps: Partial<IAllProps>) {
+  public componentDidUpdate(prevProps: Partial<IAllProps>) {
     if (this.editor && this.editor.initialized) {
       bindHandlers(this.editor, this.props, this.boundHandlers);
 
@@ -77,7 +86,9 @@ export class Editor extends React.Component<IAllProps> {
       ScriptLoader.load(
         this.elementRef.current.ownerDocument,
         this.getScriptSrc(),
-        this.initialise
+        this.initialise,
+        this.props.loadTimeOut,
+        this.props.scriptAttributes
       );
     }
   }
@@ -143,7 +154,7 @@ export class Editor extends React.Component<IAllProps> {
     const editor = this.editor;
     if (editor) {
       const newContent = editor.getContent({ format: this.props.outputFormat });
-  
+
       if (newContent !== this.currentContent) {
         this.currentContent = newContent;
         if (isFunction(this.props.onEditorChange)) {
@@ -157,15 +168,15 @@ export class Editor extends React.Component<IAllProps> {
     const editor = this.editor;
     if (editor) {
       editor.setContent(this.getInitialValue());
-  
+
       if (isFunction(this.props.onEditorChange)) {
         editor.on('change keyup setcontent', this.handleEditorChange);
       }
-  
+
       if (isFunction(this.props.onInit)) {
         this.props.onInit(initEvent, editor);
       }
-  
+
       bindHandlers(editor, this.props, this.boundHandlers);
     }
   }


### PR DESCRIPTION
### Script loading affects the load time of a page by a greater extent, which is a negative in terms of SEO.

![Screenshot 2020-09-10 at 2 11 51 AM](https://user-images.githubusercontent.com/22110988/92652836-20e09380-f30b-11ea-9d30-b5784eb54d4b.png)


So usually attributes like async or defer are provided in the script tag, that does the job to some extent, but still, google wait for the script to load and count it in the page load time. 

So people also add a setTimeout to the script loader for those scripts that is not necessary for google. For example Google Adsense script. But the same thing cannot be applied to all the scripts, as analytics script should be loaded right away to track each page view.

Now, if we come to the Editor, if the editor is the main content of the page, like a blog WYSIWYG tool, then faster the script loads favors the page, but in some cases, where the editor is being used in comment section at the bottom of the page (my case), need not load with content, and can be load after few seconds.

So considering these optimizations I have added two props, one for `loadTimeout` and the other for the script tag attributes async and defer (can be added more in the future).