### PR TITLE
Add onEditorReady callback

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -36,6 +36,7 @@ export interface IProps {
     defer?: boolean;
     delay?: number;
   };
+  onEditorReady: (editor: TinyMCEEditor) => void;
 }
 
 export interface IAllProps extends Partial<IProps>, Partial<IEvents> { }
@@ -181,6 +182,10 @@ export class Editor extends React.Component<IAllProps> {
       }
 
       bindHandlers(editor, this.props, this.boundHandlers);
+
+      if (this.props.onEditorReady) {
+        this.props.onEditorReady(editor);
+      }
     }
   }
 

--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -41,6 +41,8 @@ export interface IProps {
 
 export interface IAllProps extends Partial<IProps>, Partial<IEvents> { }
 
+export interface ITinyMCEEditor extends TinyMCEEditor { }
+
 export class Editor extends React.Component<IAllProps> {
   public static propTypes: IEditorPropTypes = EditorPropTypes;
 

--- a/src/main/ts/components/EditorPropTypes.ts
+++ b/src/main/ts/components/EditorPropTypes.ts
@@ -102,5 +102,6 @@ export const EditorPropTypes: IEditorPropTypes = {
     'defer': PropTypes.bool,
     'delay': PropTypes.number
   }),
+  onEditorReady: PropTypes.func,
   ...eventPropTypes
 };

--- a/src/main/ts/index.tsx
+++ b/src/main/ts/index.tsx
@@ -6,6 +6,4 @@
  *
  */
 
-import { Editor, IAllProps } from './components/Editor';
-
-export { Editor, IAllProps };
+export * from './components/Editor';


### PR DESCRIPTION
## Description
The package is lacking ability to use `tynyMCE` instance after editor was initiated.

### Usage:
```js
const EditorContainer = () => {
  const [editor, setEditor] = React.useState();

  return <Editor onEditorReady={ed => setEditor(ed)}>
}
```
Now we can easily use it like this `editor?.execCommand('mceInsertContent', false, '<p>Inserted programatically</p>');`

### Changes
1. `onEditorReady` implementation on `Editor` component
2. Extend propTypes with `onEditorReady` function
3. Add `ITinyMCEEditor` interface export
4. Change export in `index.tsx` to `export *` because noticed some bugs when using [Snowpack](https://www.snowpack.dev/) with typescript