### PR TITLE
INT-2330: Lookup event handlers at call time instead of rebinding on every change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed event binding to lookup handlers at call time instead of rebinding on every change.
+
 ## [3.9.0] - 2021-01-11
 ### Changed
 - Adopted beehive-flow branching and versioning process/tooling.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@ephox/agar": "^5.1.1",
     "@ephox/bedrock-client": "^11.0.0",
     "@ephox/bedrock-server": "^11.0.2",
+    "@ephox/katamari": "^7.1.1",
     "@ephox/mcagar": "^5.1.1",
     "@ephox/sand": "^4.0.3",
     "@ephox/sugar": "^7.0.3",

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -16,13 +16,13 @@ const isEventProp = (name: string): name is keyof IEventPropTypes => name in eve
 
 const eventAttrToEventName = <T extends string>(attrName: `on${T}`): T => attrName.substr(2) as T;
 
-// eslint-disable-next-line max-len
-export const bindHandlers = (editor: TinyMCEEditor, prevProps: Partial<IAllProps>, props: Partial<IAllProps>, boundHandlers: Record<string, (event: EditorEvent<unknown>) => unknown>): void => bindHandlers2(editor.on.bind(editor), editor.off.bind(editor), (handler) => (e) => handler(e, editor), prevProps, props, boundHandlers);
+type PropLookup = <K extends keyof IAllProps>(key: K) => IAllProps[K] | undefined;
 
-export const bindHandlers2 = <H> (
+export const configHandlers2 = <H> (
+  handlerLookup: PropLookup,
   on: (name: string, handler: H) => void,
   off: (name: string, handler: H) => void,
-  adapter: (handler: (event: EditorEvent<unknown>, editor: TinyMCEEditor) => unknown) => H,
+  adapter: <K extends keyof IEventPropTypes> (lookup: PropLookup, key: K) => H,
   prevProps: Partial<IAllProps>,
   props: Partial<IAllProps>,
   boundHandlers: Record<string, H>
@@ -31,10 +31,9 @@ export const bindHandlers2 = <H> (
   const currEventKeys = Object.keys(props).filter(isEventProp);
 
   const removedKeys = prevEventKeys.filter((key) => props[key] === undefined);
-  const changedKeys = currEventKeys.filter((key) => prevProps[key] !== undefined && prevProps[key] !== props[key]);
   const addedKeys = currEventKeys.filter((key) => prevProps[key] === undefined);
 
-  [ ...removedKeys, ...changedKeys ].forEach((key) => {
+  removedKeys.forEach((key) => {
     // remove event handler
     const eventName = eventAttrToEventName(key);
     const wrappedHandler = boundHandlers[eventName];
@@ -42,17 +41,30 @@ export const bindHandlers2 = <H> (
     delete boundHandlers[eventName];
   });
 
-  [ ...changedKeys, ...addedKeys ].forEach((key) => {
-    // add event handler
-    const handler = props[key];
-    if (handler !== undefined) {
-      const eventName = eventAttrToEventName(key);
-      const wrappedHandler = adapter(handler as (event: EditorEvent<unknown>, editor: TinyMCEEditor) => unknown);
-      boundHandlers[eventName] = wrappedHandler;
-      on(eventName, wrappedHandler);
-    }
+  addedKeys.forEach((key) => {
+    const wrappedHandler = adapter(handlerLookup, key);
+    const eventName = eventAttrToEventName(key);
+    boundHandlers[eventName] = wrappedHandler;
+    on(eventName, wrappedHandler);
   });
 };
+
+export const configHandlers = (
+  editor: TinyMCEEditor,
+  prevProps: Partial<IAllProps>,
+  props: Partial<IAllProps>,
+  boundHandlers: Record<string, (event: EditorEvent<any>) => unknown>,
+  lookup: PropLookup
+): void =>
+  configHandlers2(
+    lookup,
+    editor.on.bind(editor),
+    editor.off.bind(editor),
+    (handlerLookup, key) => (e) => handlerLookup(key)?.(e, editor),
+    prevProps,
+    props,
+    boundHandlers
+  );
 
 let unique = 0;
 

--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 import { IEvents } from '../Events';
 import { ScriptLoader } from '../ScriptLoader';
 import { getTinymce } from '../TinyMCE';
-import { bindHandlers, isFunction, isTextarea, mergePlugins, uuid } from '../Utils';
+import { isFunction, isTextarea, mergePlugins, uuid, configHandlers } from '../Utils';
 import { EditorPropTypes, IEditorPropTypes } from './EditorPropTypes';
 import { Editor as TinyMCEEditor, EditorEvent, Events, RawEditorSettings } from 'tinymce';
 
@@ -63,8 +63,7 @@ export class Editor extends React.Component<IAllProps> {
 
   public componentDidUpdate(prevProps: Partial<IAllProps>) {
     if (this.editor && this.editor.initialized) {
-      bindHandlers(this.editor, prevProps, this.props, this.boundHandlers);
-
+      this.bindHandlers(prevProps);
       this.currentContent = this.currentContent ?? this.editor.getContent({ format: this.props.outputFormat });
 
       if (typeof this.props.value === 'string' && this.props.value !== prevProps.value && this.props.value !== this.currentContent) {
@@ -149,6 +148,13 @@ export class Editor extends React.Component<IAllProps> {
     }
   }
 
+  private bindHandlers(prevProps: Partial<IAllProps>) {
+    if (this.editor !== undefined) {
+      // typescript chokes trying to understand the type of the lookup function
+      configHandlers(this.editor, prevProps, this.props, this.boundHandlers, (key) => this.props[key] as any);
+    }
+  }
+
   private handleEditorChange = (_evt: EditorEvent<unknown>) => {
     const editor = this.editor;
     if (editor) {
@@ -179,7 +185,7 @@ export class Editor extends React.Component<IAllProps> {
         this.props.onInit(initEvent, editor);
       }
 
-      bindHandlers(editor, {}, this.props, this.boundHandlers);
+      this.bindHandlers({});
     }
   };
 

--- a/src/test/ts/browser/EventBindingTest.ts
+++ b/src/test/ts/browser/EventBindingTest.ts
@@ -1,37 +1,40 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Assert, UnitTest } from '@ephox/bedrock-client';
-import { EditorEvent, Editor as TinyMCEEditor } from 'tinymce';
-import { bindHandlers2 } from '../../../main/ts/Utils';
+import { Arr, Obj, Fun } from '@ephox/katamari';
+import { IAllProps } from 'src/main/ts/components/Editor';
+import { configHandlers2 } from '../../../main/ts/Utils';
 
-type ReactHandler = (event: EditorEvent<unknown>, editor: TinyMCEEditor) => unknown;
-interface Handler { wrapped: ReactHandler }
+interface Handler { key: string }
 
 UnitTest.test('Event binding test', () => {
   let calls: {type: 'on' | 'off'; name: string; handler: Handler}[];
   let boundHandlers: Record<string, Handler>;
 
-  const check = (offHandlers: Record<string, ReactHandler>, onHandlers: Record<string, ReactHandler>, activeHandlers: Record<string, ReactHandler>) => {
-    const offCount = Object.keys(offHandlers).length;
-    const onCount = Object.keys(onHandlers).length;
-    Assert.eq('Expected number of calls to be sum of handlers removed and handlers added', offCount + onCount, calls.length);
+  const check = (handlers: Record<string, 'off' | 'on'>, activeHandlers: string[]) => {
+    const onHandlers = Obj.keys(Obj.filter(handlers, (value) => value === 'on'));
+    const offHandlers = Obj.keys(Obj.filter(handlers, (value) => value === 'off'));
+    Assert.eq('Expected number of calls to be sum of handlers removed and handlers added', onHandlers.length + offHandlers.length, calls.length);
     let i: number;
-    for (i = 0; i < offCount; i++) {
+    for (i = 0; i < offHandlers.length; i++) {
       const value = calls[i];
       Assert.eq('Call type did not match expected', 'off', value.type);
-      Assert.eq('Handler did not match expected', offHandlers[value.name], value.handler.wrapped);
+      Assert.eq('Handler did not match expected', handlers[value.name], 'off');
     }
     for (; i < calls.length; i++) {
       const value = calls[i];
       Assert.eq('Call type did not match expected', 'on', value.type);
-      Assert.eq('Handler did not match expected', onHandlers[value.name], value.handler.wrapped);
+      Assert.eq('Handler did not match expected', handlers[value.name], 'on');
     }
-    Assert.eq('Bound handlers did not match expected', Object.keys(activeHandlers).length, Object.keys(boundHandlers).length);
-
+    Assert.eq('Bound handlers did not match expected', activeHandlers.length, Object.keys(boundHandlers).length);
+    Obj.each(boundHandlers, (boundHandler) => {
+      Assert.eq('Expected bound handler to be active', true, Arr.contains(activeHandlers, boundHandler.key));
+    });
   };
 
   const on = (name: string, handler: Handler, _prepend?: boolean) => calls.push({ type: 'on', name, handler });
   const off = (name: string, handler: Handler) => calls.push({ type: 'off', name, handler });
-  const adapter = (wrapped: ReactHandler): Handler => ({ wrapped });
+  const adapter = (lookup: typeof dummyLookupProp, key: string): Handler => ({ key });
+  const dummyLookupProp: any = <K extends keyof IAllProps>(_key: K) => Fun.die('not implemented');
 
   // dummy functions for handlers
   const focusHandler = () => {};
@@ -40,21 +43,22 @@ UnitTest.test('Event binding test', () => {
   // check no handlers
   calls = [];
   boundHandlers = {};
-  bindHandlers2(on, off, adapter, {}, {}, boundHandlers);
-  check({}, {}, {});
+  configHandlers2(dummyLookupProp, on, off, adapter, {}, {}, boundHandlers);
+  check({}, []);
 
   // check adding handlers
   // nothing should be removed and the focus and blur handler should be added
   calls = [];
   boundHandlers = {};
-  bindHandlers2(on, off, adapter, {}, { onFocus: focusHandler, onBlur: blurHandler }, boundHandlers);
-  check({}, { Focus: focusHandler, Blur: blurHandler }, { Focus: focusHandler, Blur: blurHandler });
+  configHandlers2(dummyLookupProp, on, off, adapter, {}, { onFocus: focusHandler, onBlur: blurHandler }, boundHandlers);
+  check({ Focus: 'on', Blur: 'on' }, [ 'onFocus', 'onBlur' ]);
 
   // check changing an unrelated property while keeping handlers the same
   // nothing should be added or removed and the bound handlers should stay the same
   calls = [];
-  boundHandlers = { Focus: adapter(focusHandler), Blur: adapter(blurHandler) };
-  bindHandlers2(
+  boundHandlers = { Focus: adapter(focusHandler, 'onFocus'), Blur: adapter(blurHandler, 'onBlur') };
+  configHandlers2(
+    dummyLookupProp,
     on,
     off,
     adapter,
@@ -62,13 +66,13 @@ UnitTest.test('Event binding test', () => {
     { onFocus: focusHandler, onBlur: blurHandler, disabled: false },
     boundHandlers
   );
-  check({}, {}, { Focus: focusHandler, Blur: blurHandler });
+  check({}, [ 'onFocus', 'onBlur' ]);
 
   // check removing a handler for Blur while keeping the Focus handler
   // the blur handler should be removed and the focus handler should remain afterwards
   calls = [];
-  boundHandlers = { Focus: adapter(focusHandler), Blur: adapter(blurHandler) };
-  bindHandlers2(on, off, adapter, { onFocus: focusHandler, onBlur: blurHandler }, { onFocus: focusHandler }, boundHandlers);
-  check({ Blur: blurHandler }, {}, { Focus: focusHandler });
+  boundHandlers = { Focus: adapter(focusHandler, 'onFocus'), Blur: adapter(blurHandler, 'onBlur') };
+  configHandlers2(dummyLookupProp, on, off, adapter, { onFocus: focusHandler, onBlur: blurHandler }, { onFocus: focusHandler }, boundHandlers);
+  check({ Blur: 'off' }, [ 'onFocus' ]);
 
 });


### PR DESCRIPTION
In modern react it is common to use a function for stateful components like this:
```tsx
import React from "react";
import ReactDOM from "react-dom";
import { Editor } from "@tinymce/tinymce-react";

function App() {
  const [html, setHtml] = React.useState(
    "<p>The quick <b>brown</b> fox <i>jumps</i> over the <u>lazy</u> dog.</p>"
  );
  const [text, setText] = React.useState("");
  return (
    <>
      <h2>Rich Text</h2>
      <Editor
        apiKey="..."
        value={html}
        onEditorChange={(newHtml, editor) => {
          setHtml(newHtml);
          setText(editor.getContent({ format: "text" }));
        }}
        onInit={(_, editor) => {
          setText(editor.getContent({ format: "text" }));
        }}
      />
      <h2>HTML</h2>
      <textarea
        readOnly={true}
        value={html}
        style={{ width: "100%", height: "100px" }}
      />
      <h2>Plain Text</h2>
      <textarea
        readOnly={true}
        value={text}
        style={{ width: "100%", height: "100px" }}
      />
    </>
  );
}

const rootElement = document.getElementById("root");
ReactDOM.render(<App />, rootElement);
```
The problem here is that the value to the prop `onInit` is created every render and because it is a function that means that it is different when the value is compared to the previous value.

The event handling code would then dutifully unbind the event and rebind it with the new handler. Aside from exposing a bug in TinyMCE's event unbinding during init (which can cause a crash, see jira ) this also is rather inefficient.

This can be worked around by using a class component or by using `useRef` to cache the function however both solutions are messy and hard to understand.

As we must proxy the event handler anyway (due to differing signatures) it seems best to make the proxy event handler lookup the correct handler at the call time rather than at the bind time. This means that event handlers are only bound when the prop is first added and only have to be unbound when the prop is removed completely, not when it changes.