### PR TITLE
INT-2325: Bind event handlers at setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Fixed
+- Event handlers are registered at setup time so props like `onBeforeRenderUI` will now be called. #INT-2325
+
 ## [3.10.1] - 2021-02-01
 ### Fixed
 - Fixed CI build

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -77,7 +77,8 @@ export const uuid = (prefix: string): string => {
   return prefix + '_' + random + unique + String(time);
 };
 
-export const isTextarea = (element: Element | null): element is HTMLTextAreaElement => element !== null && element.tagName.toLowerCase() === 'textarea';
+export const isTextareaOrInput = (element: Element | null): element is (HTMLTextAreaElement | HTMLInputElement) =>
+  element !== null && (element.tagName.toLowerCase() === 'textarea' || element.tagName.toLowerCase() === 'input');
 
 const normalizePluginArray = (plugins?: string | string[]): string[] => {
   if (typeof plugins === 'undefined' || plugins === '') {

--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -151,16 +151,14 @@ export class Editor extends React.Component<IAllProps> {
     if (this.editor !== undefined) {
       // typescript chokes trying to understand the type of the lookup function
       configHandlers(this.editor, prevProps, this.props, this.boundHandlers, (key) => this.props[key] as any);
-      if (prevProps.onEditorChange === undefined) {
-        if (this.props.onEditorChange !== undefined) {
-          // added onEditorChange
-          this.editor.on('change keyup setcontent', this.handleEditorChange);
-        }
-      } else {
-        if (this.props.onEditorChange === undefined) {
-          // removed onEditorChange
-          this.editor.off('change keyup setcontent', this.handleEditorChange);
-        }
+      // check if we should monitor editor changes
+      const isValueControlled = (p: Partial<IAllProps>) => p.onEditorChange !== undefined || p.value !== undefined;
+      const wasControlled = isValueControlled(prevProps);
+      const nowControlled = isValueControlled(this.props);
+      if (!wasControlled && nowControlled) {
+        this.editor.on('change keyup setcontent', this.handleEditorChange);
+      } else if (wasControlled && !nowControlled) {
+        this.editor.off('change keyup setcontent', this.handleEditorChange);
       }
     }
   }

--- a/src/test/ts/browser/EditorBehaviorTest.ts
+++ b/src/test/ts/browser/EditorBehaviorTest.ts
@@ -37,10 +37,20 @@ UnitTest.asynctest('EditorBehaviorTest', (success, failure) => {
           onSetContent: eventStore.createHandler('onSetContent')
         }),
 
+        // tinymce native event
+        // initial content is empty as editor does not have a value or initialValue
+        eventStore.cEach<SetContentEvent>('onSetContent', (events) => {
+          Assertions.assertEq('First arg should be event from Tiny', '', events[0].editorEvent.content);
+          Assertions.assertEq('Second arg should be editor', true, isEditor(events[0].editor));
+        }),
+
+        eventStore.cClearState,
+
         cEditor(cSetContent('<p>Initial Content</p>')),
 
         // tinymce native event
         eventStore.cEach<SetContentEvent>('onSetContent', (events) => {
+          Assertions.assertEq('onSetContent should have been fired once', 1, events.length);
           Assertions.assertEq('First arg should be event from Tiny', '<p>Initial Content</p>', events[0].editorEvent.content);
           Assertions.assertEq('Second arg should be editor', true, isEditor(events[0].editor));
         }),
@@ -88,6 +98,10 @@ UnitTest.asynctest('EditorBehaviorTest', (success, failure) => {
 
       Logger.t('Providing a new event handler and re-rendering should unbind old handler and bind new handler', Chain.asStep({}, [
         cRender({ onSetContent: eventStore.createHandler('InitialHandler') }),
+        eventStore.cEach<SetContentEvent>('InitialHandler', (events) => {
+          Assertions.assertEq('Initial content is empty as editor does not have a value or initialValue', '', events[0].editorEvent.content);
+        }),
+        eventStore.cClearState,
         cEditor(cSetContent('<p>Initial Content</p>')),
 
         cReRender({ onSetContent: eventStore.createHandler('NewHandler') }),


### PR DESCRIPTION
As pointed out in this issue:
https://github.com/tinymce/tinymce-react/issues/211

A whole lot of event handlers that we were implicitly supporting were never firing because they only run during initialisation and we were binding them after initialisation.

 For example this prints nothing to the console during load:
```tsx
 <Editor
      tinymceScriptSrc="https://unpkg.com/tinymce@5.6.1/tinymce.min.js"
      onShow={() => console.log("onShow")}
      onBeforeRenderUI={() => console.log("onBeforeRenderUI")}
      onActivate={() => console.log("onActivate")}
      onPreProcess={(e) => console.log("onPreProcess")}
      onPostProcess={(e) => console.log("onPostProcess")}
      onLoadContent={() => console.log("onLoadContent")}
      value={props.value}
      onEditorChange={props.onChange}
      init={...}
    />
```

This PR attempts to bind events at setup to allow all of TinyMCE's event bindings to be useful.