### PR TITLE
feat: async value props should propagate when editor init finished

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -215,6 +215,18 @@ export class Editor extends React.Component<IAllProps> {
         if (this.props.init && isFunction(this.props.init.setup)) {
           this.props.init.setup(editor);
         }
+      },
+      init_instance_callback: (editor) => {
+        // propagate async value props when editor init finished
+        const value = this.getInitialValue();
+        if (!this.currentContent && this.currentContent !== value) {
+          this.currentContent = value;
+          editor.setContent(value as string);
+        }
+        
+        if (this.props.init && isFunction(this.props.init.init_instance_callback)) {
+          this.props.init.init_instance_callback();
+        }
       }
     };
     if (!this.inline) {


### PR DESCRIPTION
It fixes an unstable bug: sometimes the editor cannot render value props that fetch from service.
The reason of this bug is:
* when tinymce `setup()` is invoked, `initialized` of editor is `undefined`
* the order of `setup()` and `componentDidUpdate()` is unsure
* this make `componentDidUpdate()` break, because of `initialized` is `undefined`, then content cannot update

Thus, I add a `init_instance_callback` hook to update value from props.