### PR TITLE
Change implementation of `isInDoc` to work with Shadow DOM

### DIFF
--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -94,11 +94,5 @@ export const mergePlugins = (initPlugins: string | string[] | undefined, inputPl
 export const isBeforeInputEventAvailable = () => window.InputEvent && typeof (InputEvent.prototype as any).getTargetRanges === 'function';
 
 export const isInDoc = (elem: Node) => {
-  let current = elem;
-  let parent = elem.parentNode;
-  while (parent != null) {
-    current = parent;
-    parent = current.parentNode;
-  }
-  return current === elem.ownerDocument;
+  return elem.isConnected;
 };

--- a/src/main/ts/Utils.ts
+++ b/src/main/ts/Utils.ts
@@ -94,5 +94,16 @@ export const mergePlugins = (initPlugins: string | string[] | undefined, inputPl
 export const isBeforeInputEventAvailable = () => window.InputEvent && typeof (InputEvent.prototype as any).getTargetRanges === 'function';
 
 export const isInDoc = (elem: Node) => {
+  if (!('isConnected' in Node.prototype)) {
+    // Fallback for IE and old Edge
+    let current = elem;
+    let parent = elem.parentNode;
+    while (parent != null) {
+      current = parent;
+      parent = current.parentNode;
+    }
+    return current === elem.ownerDocument;
+  }
+
   return elem.isConnected;
 };


### PR DESCRIPTION
I assume `isInDoc` used to prevent users from rendering TinyMCE in elements not inserted into DOM (e.g. `let ta = document.createElement('textarea');`). However, current implementation also filters out nodes in Shadow DOM (which is actually in document and TinyMCE works fine with them). 

I changed implementation to use `Node.isConnected` (https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) which seems to be both more accurate and more simple solution.

Demonstration of `Node.isConnected`:
![image](https://user-images.githubusercontent.com/7430438/135067782-a52dce1f-8d02-4dcc-a147-515cd68d305a.png)
