### PR TITLE
PIA: fix for a larger loading time on init

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -293,7 +293,7 @@ export class Editor extends React.Component<IAllProps> {
       if (attempts === 0) {
         // we probably just need to wait for the current events to be processed
         setTimeout(() => this.initialise(1), 1);
-      } else if (attempts < 11) {
+      } else if (attempts < 100) {
         // wait for a second, polling every tenth of a second
         setTimeout(() => this.initialise(attempts + 1), 100);
       } else {


### PR DESCRIPTION
In some circumstances it can require more time to initialize. We had a bug when using it through web-components that were used in an application where other editor was used directly. That caused an exception for not having enough time to initialize. I think setTimeout of 100 should not be increased as we can rather have more function calls until it reaches 10s rather than a delayed load for where it can render faster