### PR TITLE
allow placeholder text to be set as a prop to Editor component

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -21,6 +21,7 @@ export interface IProps {
   id: string;
   inline: boolean;
   initialValue: string;
+  placeholder: string;
   onEditorChange: (a: string, editor: TinyMCEEditor) => void;
   value: string;
   init: EditorOptions & { selector?: undefined; target?: undefined };
@@ -315,6 +316,7 @@ export class Editor extends React.Component<IAllProps> {
       selector: undefined,
       target,
       readonly: this.props.disabled,
+      placeholder: this.props.placeholder,
       inline: this.inline,
       plugins: mergePlugins(this.props.init?.plugins, this.props.plugins),
       toolbar: this.props.toolbar ?? this.props.init?.toolbar,

--- a/src/main/ts/components/EditorPropTypes.ts
+++ b/src/main/ts/components/EditorPropTypes.ts
@@ -86,6 +86,7 @@ export const EditorPropTypes: IEditorPropTypes = {
   id: PropTypes.string,
   inline: PropTypes.bool,
   init: PropTypes.object,
+  placeholder: PropTypes.string,
   initialValue: PropTypes.string,
   onEditorChange: PropTypes.func,
   value: PropTypes.string,

--- a/src/stories/Editor.stories.tsx
+++ b/src/stories/Editor.stories.tsx
@@ -137,6 +137,19 @@ ToggleDisabledProp.parameters = {
   controls: { hideNoControlsWarning: true },
 };
 
+export const PlaceholderProp: Story = () => {
+  return (
+    <div>
+      <Editor
+        apiKey={apiKey}
+        placeholder="This is some placeholder text that works like a placeholder"
+      />
+    </div>
+  );
+};
+
+PlaceholderProp.storyName = 'Set placeholder text';
+
 export const CloudChannelSetTo5Dev: Story = () => (
   <div>
     <Editor


### PR DESCRIPTION
Refs https://github.com/tinymce/tinymce-react/issues/335

This allows `placeholder` to be set as a prop to the Editor component, and I have added a storybook component to show / test that it works.

I apologize I was unable to get tests running locally, so have not added tests, but happy to work on that with some guidance.

Thanks very much for this project!