### PR TITLE
INT-2871: Added props for various error handling events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added props for the events `SkinLoadError`, `ThemeLoadError`, `ModelLoadError`, `PluginLoadError`, `IconsLoadError` and `LanguageLoadError`.
+
 ### Fixed
 - Updated issue templates with updated codesandbox
 - Updated the readme with links to the TinyMCE 6 documentation

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "typescript": "~4.6.3",
     "webpack": "^5.71.0"
   },
-  "version": "4.0.1-rc",
+  "version": "4.1.0-rc",
   "name": "@tinymce/tinymce-react"
 }

--- a/src/main/ts/Events.ts
+++ b/src/main/ts/Events.ts
@@ -78,6 +78,12 @@ export interface ITinyEvents {
   onSubmit: EventHandler<unknown>;
   onUndo: EEventHandler<'Undo'>;
   onVisualAid: EventHandler<unknown>;
+  onSkinLoadError: EEventHandler<'SkinLoadError'>;
+  onThemeLoadError: EEventHandler<'ThemeLoadError'>;
+  onModelLoadError: EEventHandler<'ModelLoadError'>;
+  onPluginLoadError: EEventHandler<'PluginLoadError'>;
+  onIconsLoadError: EEventHandler<'IconsLoadError'>;
+  onLanguageLoadError: EEventHandler<'LanguageLoadError'>;
 }
 
 export interface IEvents extends INativeEvents, ITinyEvents {}

--- a/src/main/ts/components/EditorPropTypes.ts
+++ b/src/main/ts/components/EditorPropTypes.ts
@@ -78,7 +78,13 @@ export const eventPropTypes: IEventPropTypes = {
   onShow: PropTypes.func,
   onSubmit: PropTypes.func,
   onUndo: PropTypes.func,
-  onVisualAid: PropTypes.func
+  onVisualAid: PropTypes.func,
+  onSkinLoadError: PropTypes.func,
+  onThemeLoadError: PropTypes.func,
+  onModelLoadError: PropTypes.func,
+  onPluginLoadError: PropTypes.func,
+  onIconsLoadError: PropTypes.func,
+  onLanguageLoadError: PropTypes.func,
 };
 
 export const EditorPropTypes: IEditorPropTypes = {


### PR DESCRIPTION
Newly supported events:
- SkinLoadError
- ThemeLoadError
- ModelLoadError
- PluginLoadError
- IconsLoadError
- LanguageLoadError

Related to https://github.com/tinymce/tinymce-react/issues/341