### PR TITLE
TINY-9797: fix bug on remove

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -148,8 +148,10 @@ export class Editor extends React.Component<IAllProps> {
         editor.off(eventName, this.boundHandlers[eventName]);
       });
       this.boundHandlers = {};
-      editor.remove();
-      this.editor = undefined;
+      setTimeout(() => {
+        editor.remove();
+        this.editor = undefined;
+      }, 0);
     }
   }
 


### PR DESCRIPTION
There is a bug in React that cause an error if a component is unmounted in a specific situation.

I opened an issue in the React repo: https://github.com/facebook/react/issues/26980

This fix seems to solve the issue since it gives the time to React to do its things before the unmount of the component.

Even if it is not the final solution I think we can take this waiting until we have a fix for React