### PR TITLE
INT-3259: Added github action for labeling and closing stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Respond with a comment or this will be closed in 7 days.'
           days-before-stale: 30 # Days before an issue becomes stale
-          days-before-close: 7 # Days before an issue with no activity after begin labelled "stale" is closed
+          days-before-close: 7 # Days before a stale labelled issue is closed
           any-of-labels: 'needs: more info'
           labels-to-remove-when-unstale: 'needs: more info'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,7 @@ name: "Stale"
 
 on:
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "0 0 * * *"
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          stale-issue-message: 'This issue is stale because it has been open for 7 days with no activity. Respond with a comment or this will be closed in 7 days.'
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Respond with a comment or this will be closed in 7 days.'
           days-before-stale: 30 # Days before an issue becomes stale
           days-before-close: 7 # Days before an issue with no activity after begin labelled "stale" is closed
           any-of-labels: 'needs: more info'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: "Stale"
+
+# This uses Github actions minutes. To learn more: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  stale:
+    name: Close stale issues
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: write # only for delete-branch option
+      issues: write
+      # pull-requests: write # only makes issues stale, not PRs
+
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open for 7 days with no activity. Respond with a comment or this will be closed in 7 days.'
+          days-before-stale: 30 # Days before an issue becomes stale
+          days-before-close: 7 # Days before an issue with no activity after begin labelled "stale" is closed
+          any-of-labels: 'needs: more info'
+          labels-to-remove-when-unstale: 'needs: more info'
+


### PR DESCRIPTION
Jira ticket: https://ephocks.atlassian.net/browse/INT-3259

Description of changes:
Added a Github action that labels any issues that have the "needs: more info" label, with the "stale" label, after 30 days have elapsed since last being updated. A further 7 days with no response will close the issue. This action runs once a day.

See for more info on the stale GH action: https://github.com/actions/stale#days-before-stale
