### PR TITLE
INT-3287: Add `readonly` prop as an overridden init prop

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -15,7 +15,7 @@ export interface IProps {
   initialValue: string;
   onEditorChange: (a: string, editor: TinyMCEEditor) => void;
   value: string;
-  init: EditorOptions & { selector?: undefined; target?: undefined };
+  init: EditorOptions & Partial<Record<'selector' | 'target' | 'readonly', undefined>>;
   tagName: string;
   cloudChannel: string;
   plugins: NonNullable<EditorOptions['plugins']>;


### PR DESCRIPTION
Jira ticket: INT-3287

Description of changes: 
As documented [here](https://www.tiny.cloud/docs/tinymce/6/react-ref/#init), `readonly` is overridden by the integration. So the `init` prop type should reflect that to be consistent with the others (`target` & `selector`).

Related: #477
