### PR TITLE
INT-3301: Fix storybook github pages load error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch": "tsc -w -p ./tsconfig.es2015.json",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "deploy-storybook": "storybook build && gh-pages -d ./storybook-static -u 'tiny-bot <no-reply@tiny.cloud>'"
+    "deploy-storybook": "storybook build && gh-pages -d ./storybook-static -u 'tiny-bot <no-reply@tiny.cloud>' --nojekyll"
   },
   "keywords": [],
   "author": "Ephox Corporation DBA Tiny Technologies, Inc.",


### PR DESCRIPTION
The swap from using Webpack to Vite for the storybook build introduced a page load error: `Failed to fetch dynamically imported module...`. So disabling jekyll fixes this.

Changes:
- Added `--nojekyll` flag to `gh-pages` command. This adds a `.nojekyll` file to the build.