### PR TITLE
INT-3300: Update doc links to point to version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Fixed
-- Updated links in the readme to point to the correct TinyMCE 7 documentation. #INT-3300
-
 ## 5.0.0 - 2024-03-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+- Updated links in the readme to point to the correct TinyMCE 7 documentation. #INT-3300
+
 ## 5.0.0 - 2024-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinymce) to make it easier to use in a React application.
 
-* If you need detailed documentation on TinyMCE, see: [TinyMCE Documentation](https://www.tiny.cloud/docs/tinymce/6/).
-* For the TinyMCE React Quick Start, see: [TinyMCE Documentation - React Integration](https://www.tiny.cloud/docs/tinymce/6/react-cloud/).
-* For the TinyMCE React Technical Reference, see: [TinyMCE Documentation - TinyMCE React Technical Reference](https://www.tiny.cloud/docs/tinymce/6/react-ref/).
+* If you need detailed documentation on TinyMCE, see: [TinyMCE Documentation](https://www.tiny.cloud/docs/tinymce/7/).
+* For the TinyMCE React Quick Start, see: [TinyMCE Documentation - React Integration](https://www.tiny.cloud/docs/tinymce/7/react-cloud/).
+* For the TinyMCE React Technical Reference, see: [TinyMCE Documentation - TinyMCE React Technical Reference](https://www.tiny.cloud/docs/tinymce/7/react-ref/).
 * For our quick demos, check out the TinyMCE React [Storybook](https://tinymce.github.io/tinymce-react/).
 
 


### PR DESCRIPTION
Swapped the links to the TinyMCE docs from version 6 to version 7.