### PR TITLE
INT-3297: Refactor tests to use BDD style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,15 @@
         "@tinymce/prefer-fun": "off",
         "@typescript-eslint/no-unsafe-argument": "off"
       }
+    },
+    {
+      "files": [
+        "src/test/**/*"
+      ],
+      "rules": {
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+        "no-var": "off" // Without this the `using` keyword causes eslint to throw an error during linting.
+      }
     }
   ]
 }

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -15,7 +15,7 @@ export interface Context {
   DOMNode: HTMLElement;
   editor: TinyMCEEditor;
   ref: React.RefObject<Editor>;
-  version: string;
+  majorVersion: string;
 }
 
 const getRoot = () => Optional.from(document.getElementById('root')).getOrThunk(() => {
@@ -69,7 +69,7 @@ export const render = async (props: Partial<IAllProps> = {}, container: HTMLElem
                   ref,
                   editor,
                   DOMNode,
-                  version: Global.tinymce.majorVersion
+                  majorVersion: Global.tinymce.majorVersion
                 });
               });
           }, 0);

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -15,7 +15,7 @@ export interface Context {
   DOMNode: HTMLElement;
   editor: TinyMCEEditor;
   ref: React.RefObject<Editor>;
-  majorVersion: string;
+  version: string;
 }
 
 const getRoot = () => Optional.from(document.getElementById('root')).getOrThunk(() => {
@@ -69,7 +69,7 @@ export const render = async (props: Partial<IAllProps> = {}, container: HTMLElem
                   ref,
                   editor,
                   DOMNode,
-                  majorVersion: Global.tinymce.majorVersion
+                  version: Global.tinymce.majorVersion
                 });
               });
           }, 0);

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -15,7 +15,6 @@ export interface Context {
   DOMNode: HTMLElement;
   editor: TinyMCEEditor;
   ref: React.RefObject<Editor>;
-  version: string;
 }
 
 const getRoot = () => Optional.from(document.getElementById('root')).getOrThunk(() => {
@@ -69,7 +68,6 @@ export const render = async (props: Partial<IAllProps> = {}, container: HTMLElem
                   ref,
                   editor,
                   DOMNode,
-                  version: Global.tinymce.majorVersion
                 });
               });
           }, 0);

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -86,7 +86,7 @@ export const render = async (props: Partial<IAllProps> = {}, container: HTMLElem
 };
 
 type RenderWithVersion = (
-  props: Omit<IAllProps, 'cloudChannel' | 'licenseKey' | 'tinymceScriptSrc'>,
+  props: Omit<IAllProps, 'cloudChannel' | 'tinymceScriptSrc'>,
   container?: HTMLElement | HTMLDivElement
 ) => Promise<ReactEditorContext>;
 

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -1,10 +1,11 @@
-import { Arr, Fun, Global, Optional, Strings } from '@ephox/katamari';
-import { Attribute, Remove, SelectorFilter, SugarElement, SugarNode } from '@ephox/sugar';
+import { Fun, Optional } from '@ephox/katamari';
+import { SugarElement, SugarNode } from '@ephox/sugar';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Editor, IAllProps, IProps } from '../../../main/ts/components/Editor';
+import { Editor, IAllProps, IProps, Version } from '../../../main/ts/components/Editor';
 import { Editor as TinyMCEEditor } from 'tinymce';
-import { ScriptLoader } from '../../../main/ts/ScriptLoader2';
+import { before, context } from '@ephox/bedrock-client';
+import { VersionLoader } from '@tinymce/miniature';
 
 // @ts-expect-error Remove when dispose polyfill is not needed
 Symbol.dispose ??= Symbol('Symbol.dispose');
@@ -28,28 +29,12 @@ export interface ReactEditorContext extends Context, Disposable {
   remove(): void;
 }
 
-const deleteTinymce = () => {
-  ScriptLoader.reinitialize();
-
-  delete Global.tinymce;
-  delete Global.tinyMCE;
-  const hasTinymceUri = (attrName: string) => (elm: SugarElement<Element>) =>
-    Attribute.getOpt(elm, attrName).exists((src) => Strings.contains(src, 'tinymce'));
-
-  const elements = Arr.flatten([
-    Arr.filter(SelectorFilter.all('script'), hasTinymceUri('src')),
-    Arr.filter(SelectorFilter.all('link'), hasTinymceUri('href')),
-  ]);
-
-  Arr.each(elements, Remove.remove);
-};
-
 export const render = async (props: Partial<IAllProps> = {}, container: HTMLElement = getRoot()): Promise<ReactEditorContext> => {
   const originalInit = props.init || {};
   const originalSetup = originalInit.setup || Fun.noop;
   const ref = React.createRef<Editor>();
 
-  const context = await new Promise<Context>((resolve, reject) => {
+  const ctx = await new Promise<Context>((resolve, reject) => {
     const init: IProps['init'] = {
       ...originalInit,
       setup: (editor) => {
@@ -87,16 +72,30 @@ export const render = async (props: Partial<IAllProps> = {}, container: HTMLElem
 
   const remove = () => {
     ReactDOM.unmountComponentAtNode(container);
-    deleteTinymce();
   };
 
   return {
-    ...context,
+    ...ctx,
     /** By rendering the Editor into the same root, React will perform a diff and update. */
     reRender: (newProps: IAllProps) => new Promise<void>((resolve) =>
-      ReactDOM.render(<div><Editor apiKey='no-api-key' ref={context.ref} {...newProps} /></div>, container, resolve)
+      ReactDOM.render(<div><Editor apiKey='no-api-key' ref={ctx.ref} {...newProps} /></div>, container, resolve)
     ),
     remove,
     [Symbol.dispose]: remove
   };
+};
+
+type RenderWithVersion = (
+  props: Omit<IAllProps, 'cloudChannel' | 'licenseKey' | 'tinymceScriptSrc'>,
+  container?: HTMLElement | HTMLDivElement
+) => Promise<ReactEditorContext>;
+
+export const withVersion = (version: Version, fn: (render: RenderWithVersion) => void): void => {
+  context(`TinyMCE (${version})`, () => {
+    before(async () => {
+      await VersionLoader.pLoadVersion(version);
+    });
+
+    fn(render as RenderWithVersion);
+  });
 };

--- a/src/test/ts/alien/Loader.tsx
+++ b/src/test/ts/alien/Loader.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Editor, IAllProps, IProps } from '../../../main/ts/components/Editor';
 import { Editor as TinyMCEEditor } from 'tinymce';
-import { ScriptLoader } from 'src/main/ts/ScriptLoader2';
+import { ScriptLoader } from '../../../main/ts/ScriptLoader2';
 
 // @ts-expect-error Remove when dispose polyfill is not needed
 Symbol.dispose ??= Symbol('Symbol.dispose');

--- a/src/test/ts/alien/TestHelpers.ts
+++ b/src/test/ts/alien/TestHelpers.ts
@@ -1,6 +1,5 @@
-import { Chain, Assertions } from '@ephox/agar';
+import { Assertions } from '@ephox/agar';
 import { Cell, Obj } from '@ephox/katamari';
-import { ApiChains } from '@ephox/mcagar';
 import { Version } from 'src/main/ts/components/Editor';
 import { Editor as TinyMCEEditor } from 'tinymce';
 
@@ -13,6 +12,8 @@ type HandlerType<A> = (a: A, editor: TinyMCEEditor) => unknown;
 
 const VERSIONS: Version[] = [ '4', '5', '6', '7' ];
 const CLOUD_VERSIONS: Version[] = [ '5', '6', '7' ];
+
+const VALID_API_KEY = 'qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc';
 
 const EventStore = () => {
   const state: Cell<Record<string, EventHandlerArgs<unknown>[]>> = Cell({});
@@ -30,32 +31,25 @@ const EventStore = () => {
     });
   };
 
-  const cEach = <T>(name: string, assertState: (state: EventHandlerArgs<T>[]) => void) => Chain.fromChains([
-    Chain.op(() => {
-      Assertions.assertEq('State from "' + name + '" handler should exist', true, name in state.get());
-      assertState(state.get()[name] as unknown as EventHandlerArgs<T>[]);
-    })
-  ]);
+  const each = <T>(name: string, assertState: (state: EventHandlerArgs<T>[]) => void) => {
+    Assertions.assertEq('State from "' + name + '" handler should exist', true, name in state.get());
+    assertState(state.get()[name] as unknown as EventHandlerArgs<T>[]);
+  };
 
-  const cClearState = Chain.op(() => {
+  const clearState = () => {
     state.set({});
-  });
+  };
 
   return {
-    cEach,
+    each,
     createHandler,
-    cClearState
+    clearState
   };
 };
 
-// casting needed due to fake types used in mcagar
-const cSetContent = (content: string) => ApiChains.cSetContent(content) as unknown as Chain<TinyMCEEditor, TinyMCEEditor>;
-const cAssertContent = (content: string) => ApiChains.cAssertContent(content) as unknown as Chain<TinyMCEEditor, TinyMCEEditor>;
-
 export {
+  VALID_API_KEY,
   EventStore,
-  cSetContent,
-  cAssertContent,
   VERSIONS,
   CLOUD_VERSIONS,
   Version

--- a/src/test/ts/browser/EditorBehaviorTest.ts
+++ b/src/test/ts/browser/EditorBehaviorTest.ts
@@ -35,7 +35,7 @@ describe('EditorBehaviourTest', () => {
         using ctx = await render({
           cloudChannel: version,
           onEditorChange: eventStore.createHandler('onEditorChange'),
-          onSetContent: eventStore.createHandler('onSetContent')
+          onSetContent: eventStore.createHandler('onSetContent'),
         });
 
         // tinymce native event
@@ -50,12 +50,16 @@ describe('EditorBehaviourTest', () => {
           Assertions.assertEq('Second arg should be editor', true, isEditor(events[0].editor));
         });
         eventStore.clearState();
-        
+
         ctx.editor.setContent('<p>Initial Content</p>');
         // tinymce native event
         eventStore.each<SetContentEvent>('onSetContent', (events) => {
           Assertions.assertEq('onSetContent should have been fired once', 1, events.length);
-          Assertions.assertEq('First arg should be event from Tiny', '<p>Initial Content</p>', events[0].editorEvent.content);
+          Assertions.assertEq(
+            'First arg should be event from Tiny',
+            '<p>Initial Content</p>',
+            events[0].editorEvent.content
+          );
           Assertions.assertEq('Second arg should be editor', true, isEditor(events[0].editor));
         });
 
@@ -70,7 +74,7 @@ describe('EditorBehaviourTest', () => {
       it('onEditorChange should only fire when the editors content changes', async () => {
         using ctx = await render({
           cloudChannel: version,
-          onEditorChange: eventStore.createHandler('onEditorChange')
+          onEditorChange: eventStore.createHandler('onEditorChange'),
         });
 
         ctx.editor.setContent('<p>Initial Content</p>');
@@ -90,7 +94,11 @@ describe('EditorBehaviourTest', () => {
         ctx.editor.setContent('<p>New Content</p>');
 
         eventStore.each<SetContentEvent>('onSetContent', (events) => {
-          Assertions.assertEq('Should have bound handler, hence new content', '<p>New Content</p>', events[0].editorEvent.content);
+          Assertions.assertEq(
+            'Should have bound handler, hence new content',
+            '<p>New Content</p>',
+            events[0].editorEvent.content
+          );
         });
 
         eventStore.clearState();
@@ -103,20 +111,29 @@ describe('EditorBehaviourTest', () => {
             'Initial content is empty as editor does not have a value or initialValue',
             // note that this difference in behavior in 5-6 may be a bug, the team is investigating
             versionRegex.test(version) ? '<p><br data-mce-bogus="1"></p>' : '',
-            events[0].editorEvent.content);
+            events[0].editorEvent.content
+          );
         });
         eventStore.clearState();
         ctx.editor.setContent('<p>Initial Content</p>');
 
-        await ctx.reRender({ onSetContent: eventStore.createHandler('NewHandler') }),
+        await ctx.reRender({ onSetContent: eventStore.createHandler('NewHandler') });
         ctx.editor.setContent('<p>New Content</p>');
 
         eventStore.each<SetContentEvent>('InitialHandler', (events) => {
-          Assertions.assertEq('Initial handler should have been unbound, hence initial content', '<p>Initial Content</p>', events[0].editorEvent.content);
-        }),
+          Assertions.assertEq(
+            'Initial handler should have been unbound, hence initial content',
+            '<p>Initial Content</p>',
+            events[0].editorEvent.content
+          );
+        });
         eventStore.each<SetContentEvent>('NewHandler', (events) => {
-          Assertions.assertEq('New handler should have been bound, hence new content', '<p>New Content</p>', events[0].editorEvent.content);
-        })
+          Assertions.assertEq(
+            'New handler should have been bound, hence new content',
+            '<p>New Content</p>',
+            events[0].editorEvent.content
+          );
+        });
 
         eventStore.clearState();
       });

--- a/src/test/ts/browser/EditorBehaviorTest.ts
+++ b/src/test/ts/browser/EditorBehaviorTest.ts
@@ -1,7 +1,7 @@
-import { render } from '../alien/Loader';
+import * as Loader from '../alien/Loader';
 import { PlatformDetection } from '@ephox/sand';
 
-import { context, describe, it } from '@ephox/bedrock-client';
+import { describe, it } from '@ephox/bedrock-client';
 
 import { getTinymce } from '../../../main/ts/TinyMCE';
 import { EventStore, VERSIONS } from '../alien/TestHelpers';
@@ -30,10 +30,9 @@ describe('EditorBehaviourTest', () => {
   const eventStore = EventStore();
 
   VERSIONS.forEach((version) =>
-    context(`TinyMCE (${version})`, () => {
+    Loader.withVersion(version, (render) => {
       it('Assert structure of tinymce and tinymce-react events', async () => {
         using ctx = await render({
-          cloudChannel: version,
           onEditorChange: eventStore.createHandler('onEditorChange'),
           onSetContent: eventStore.createHandler('onSetContent'),
         });
@@ -73,7 +72,6 @@ describe('EditorBehaviourTest', () => {
 
       it('onEditorChange should only fire when the editors content changes', async () => {
         using ctx = await render({
-          cloudChannel: version,
           onEditorChange: eventStore.createHandler('onEditorChange'),
         });
 
@@ -87,7 +85,7 @@ describe('EditorBehaviourTest', () => {
       });
 
       it('Should be able to register an event handler after initial render', async () => {
-        using ctx = await render({ cloudChannel: version, initialValue: '<p>Initial Content</p>' });
+        using ctx = await render({ initialValue: '<p>Initial Content</p>' });
         await ctx.reRender({ onSetContent: eventStore.createHandler('onSetContent') });
 
         TinyAssertions.assertContent(ctx.editor, '<p>Initial Content</p>');
@@ -105,7 +103,7 @@ describe('EditorBehaviourTest', () => {
       });
 
       it('Providing a new event handler and re-rendering should unbind old handler and bind new handler', async () => {
-        using ctx = await render({ cloudChannel: version, onSetContent: eventStore.createHandler('InitialHandler') });
+        using ctx = await render({ onSetContent: eventStore.createHandler('InitialHandler') });
         eventStore.each<SetContentEvent>('InitialHandler', (events) => {
           Assertions.assertEq(
             'Initial content is empty as editor does not have a value or initialValue',

--- a/src/test/ts/browser/EditorInitTest.ts
+++ b/src/test/ts/browser/EditorInitTest.ts
@@ -12,9 +12,9 @@ const assertProperty = (obj: {}, propName: string, expected: unknown) => {
 
 describe('EditorInitTest', () => {
   VERSIONS.forEach((version) =>
-    context(`TinyMCE (${version})`, () => {
+    Loader.withVersion(version, (renderWithVersion) => {
       const defaultProps: IAllProps = { apiKey: VALID_API_KEY, cloudChannel: version };
-      const render = (props: IAllProps = {}) => Loader.render({ ...defaultProps, ...props });
+      const render = (props: IAllProps = {}) => renderWithVersion({ ...defaultProps, ...props });
 
       context('tagName prop changes element', () => {
         it('is div by default for inline', async () => {

--- a/src/test/ts/browser/EditorInitTest.ts
+++ b/src/test/ts/browser/EditorInitTest.ts
@@ -1,103 +1,82 @@
-import { Assertions, Chain, GeneralSteps, Logger, Pipeline } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { VersionLoader } from '@tinymce/miniature';
+import { Assertions } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
 
-import { cRemove, cRender, cDOMNode, cEditor, cReRender } from '../alien/Loader';
-import { type Version, cAssertContent, VERSIONS } from '../alien/TestHelpers';
+import { VALID_API_KEY, VERSIONS } from '../alien/TestHelpers';
+import * as Loader from '../alien/Loader';
+import { TinyAssertions } from '@ephox/mcagar';
+import { IAllProps } from 'src/main/ts';
 
-UnitTest.asynctest('Editor.test', (success, failure) => {
-  const cAssertProperty = (propName: string, expected: string) => Chain.op((el: HTMLElement) => {
-    Assertions.assertEq(propName + ' should be ' + expected, expected, (el as unknown as Record<string, unknown>)[propName]);
-  });
+function assertProperty<T extends HTMLElement | Record<string, unknown>, K extends keyof T>(obj: T, propName: K, expected: T[K]): void
+function assertProperty(obj: {}, propName: string, expected: unknown): void;
+function assertProperty(obj: Record<string, unknown>, propName: string, expected: unknown): void {
+  Assertions.assertEq(propName.toString() + ' should be ' + expected, expected, obj[propName]);
+}
 
-  const sTestVersion = (version: Version) => VersionLoader.sWithVersion(
-    version,
-    GeneralSteps.sequence([
-      Logger.t('tagName prop changes element', GeneralSteps.sequence([
-        Logger.t('it is div by default for inline', Chain.asStep({}, [
-          cRender({ inline: true }),
-          cDOMNode(cAssertProperty('tagName', 'DIV')),
-          cRemove
-        ])),
+describe('EditorInitTest', async () => {
+  VERSIONS.forEach((version) =>
+    context(`TinyMCE (${version})`, async () => {
+      const defaultProps: IAllProps = { apiKey: VALID_API_KEY, cloudChannel: version };
+      const render = (props: IAllProps = {}) => Loader.render({ ...defaultProps, ...props });
 
-        Logger.t('can be set to inline in init', Chain.asStep({}, [
-          cRender({
-            init: {
-              inline: true
-            }
-          }),
-          cDOMNode(cAssertProperty('tagName', 'DIV')),
-          cRemove
-        ])),
+      context('tagName prop changes element', () => {
+        it('is div by default for inline', async () => {
+          using ctx = await render({ inline: true });
+          assertProperty(ctx.DOMNode, 'tagName', 'DIV');
+        });
 
-        Logger.t('it can be changed to p', Chain.asStep({}, [
-          cRender({
-            inline: true,
-            tagName: 'p'
-          }),
-          cDOMNode(cAssertProperty('tagName', 'P')),
-          cRemove
-        ])),
+        it('can be set to inline in init', async () => {
+          using ctx = await render({ init: { inline: true }});
+          assertProperty(ctx.DOMNode, 'tagName', 'DIV');
+        });
 
-        Logger.t('iframe editor does not change element', Chain.asStep({}, [
-          cRender({ tagName: 'p' }),
-          cDOMNode(cAssertProperty('tagName', 'TEXTAREA')),
-          cRemove
-        ]))
-      ])),
+        it('can be changed to p', async () => {
+          using ctx = await render({ inline: true, tagName: 'p' });
+          assertProperty(ctx.DOMNode, 'tagName', 'P');
+        });
 
-      Logger.t('id is set automatically if id prop not provided', GeneralSteps.sequence([
-        Logger.t('is set normally if prop is provided', Chain.asStep({}, [
-          cRender({ id: 'test' }),
-          cDOMNode(cAssertProperty('id', 'test')),
-          cRemove
-        ])),
+        it('iframe editor does not change element', async () => {
+          using ctx = await render({ tagName: 'p' });
+          assertProperty(ctx.DOMNode, 'tagName', 'TEXTAREA');
+        });
+      });
 
-        Logger.t('gets set automatically to uuid if not set', Chain.asStep({}, [
-          cRender({}),
-          cDOMNode(Chain.op((node: Element) => {
-            Assertions.assertEq('Should not be uuid', typeof node.id === 'string' && node.id.indexOf('tiny-react') !== -1, true);
-          })),
-          cRemove
-        ])),
-      ])),
+      context('id is set automatically if id prop not provided', () => {
+        it('is set normally if prop is provided', async () => {
+          using ctx = await render({ id: 'test' });
+          assertProperty(ctx.DOMNode, 'id', 'test');
+        });
 
-      Logger.t('sets name on form', GeneralSteps.sequence([
-        Logger.t('is not set when prop is not provided', Chain.asStep({}, [
-          cRender({}),
-          cDOMNode(cAssertProperty('name', '')),
-          cRemove
-        ])),
+        it('gets set automatically to uuid if not set', async () => {
+          using ctx = await render();
+          Assertions.assertEq('Should not be uuid', typeof ctx.DOMNode.id === 'string' && ctx.DOMNode.id.indexOf('tiny-react') !== -1, true);
+        });
+      });
 
-        Logger.t('is set when prop is provided', Chain.asStep({}, [
-          cRender({ textareaName: 'test' }),
-          cDOMNode(cAssertProperty('name', 'test')),
-          cRemove
-        ])),
-      ])),
+      context('sets name on form', () => {
+        it('is not set when prop is not provided', async () => {
+          using ctx = await render();
+          assertProperty(ctx.DOMNode, 'name', '');
+        });
 
-      Logger.t('Value prop should propagate changes to editor', Chain.asStep({}, [
-        cRender({ value: '<p>Initial Value</p>' }),
-        cEditor(cAssertContent('<p>Initial Value</p>')),
-        cReRender({ value: '<p>New Value</p>' }),
-        cEditor(cAssertContent('<p>New Value</p>')),
-        cRemove
-      ])),
+        it('is set when prop is provided', async () => {
+          using ctx = await render({ textareaName: 'test' });
+          assertProperty(ctx.DOMNode, 'name', 'test');
+        });
+      });
 
-      Logger.t('Disabled prop should disable editor', Chain.asStep({}, [
-        cRender({}),
-        cEditor(Chain.op((editor) => {
-          Assertions.assertEq(
-            'Should be design mode', true, version === '4' ? !editor.readonly : editor.mode.get() === 'design');
-        })),
-        cReRender({ disabled: true }),
-        cEditor(Chain.op((editor) => {
-          Assertions.assertEq('Should be readonly mode', true, version === '4' ? editor.readonly : editor.mode.get() === 'readonly');
-        })),
-        cRemove
-      ]))
-    ])
+      it('Value prop should propagate changes to editor', async () => {
+        using ctx = await render({ value: '<p>Initial Value</p>' });
+        TinyAssertions.assertContent(ctx.editor, '<p>Initial Value</p>');
+        ctx.reRender({ ...defaultProps, value: '<p>New Value</p>' });
+        TinyAssertions.assertContent(ctx.editor, '<p>New Value</p>');
+      });
+
+      it('Disabled prop should disable editor', async () => {
+        using ctx = await render();
+        Assertions.assertEq('Should be design mode', true, ['4'].includes(version) ? !ctx.editor.readonly : ctx.editor.mode.get() === 'design');
+        ctx.reRender({ ...defaultProps, disabled: true });
+        Assertions.assertEq('Should be readonly mode', true, ['4'].includes(version) ? ctx.editor.readonly : ctx.editor.mode.get() === 'readonly');
+      });
+    })
   );
-
-  Pipeline.async({}, VERSIONS.map(sTestVersion), success, failure);
 });

--- a/src/test/ts/browser/EditorInitTest.ts
+++ b/src/test/ts/browser/EditorInitTest.ts
@@ -6,15 +6,13 @@ import * as Loader from '../alien/Loader';
 import { TinyAssertions } from '@ephox/mcagar';
 import { IAllProps } from 'src/main/ts';
 
-function assertProperty<T extends HTMLElement | Record<string, unknown>, K extends keyof T>(obj: T, propName: K, expected: T[K]): void
-function assertProperty(obj: {}, propName: string, expected: unknown): void;
-function assertProperty(obj: Record<string, unknown>, propName: string, expected: unknown): void {
-  Assertions.assertEq(propName.toString() + ' should be ' + expected, expected, obj[propName]);
-}
+const assertProperty = (obj: {}, propName: string, expected: unknown) => {
+  Assertions.assertEq(propName.toString() + ' should be ' + expected, expected, (obj as any)[propName]);
+};
 
-describe('EditorInitTest', async () => {
+describe('EditorInitTest', () => {
   VERSIONS.forEach((version) =>
-    context(`TinyMCE (${version})`, async () => {
+    context(`TinyMCE (${version})`, () => {
       const defaultProps: IAllProps = { apiKey: VALID_API_KEY, cloudChannel: version };
       const render = (props: IAllProps = {}) => Loader.render({ ...defaultProps, ...props });
 
@@ -73,9 +71,9 @@ describe('EditorInitTest', async () => {
 
       it('Disabled prop should disable editor', async () => {
         using ctx = await render();
-        Assertions.assertEq('Should be design mode', true, ['4'].includes(version) ? !ctx.editor.readonly : ctx.editor.mode.get() === 'design');
+        Assertions.assertEq('Should be design mode', true, '4' === version ? !ctx.editor.readonly : ctx.editor.mode.get() === 'design');
         ctx.reRender({ ...defaultProps, disabled: true });
-        Assertions.assertEq('Should be readonly mode', true, ['4'].includes(version) ? ctx.editor.readonly : ctx.editor.mode.get() === 'readonly');
+        Assertions.assertEq('Should be readonly mode', true, '4' === version ? ctx.editor.readonly : ctx.editor.mode.get() === 'readonly');
       });
     })
   );

--- a/src/test/ts/browser/EventBindingTest.ts
+++ b/src/test/ts/browser/EventBindingTest.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
-import { Assert, UnitTest } from '@ephox/bedrock-client';
+import { Assert, describe } from '@ephox/bedrock-client';
 import { Arr, Obj, Fun } from '@ephox/katamari';
 import { IAllProps } from 'src/main/ts/components/Editor';
 import { configHandlers2 } from '../../../main/ts/Utils';
@@ -8,7 +7,7 @@ interface Handler {
   key: string;
 }
 
-UnitTest.test('Event binding test', () => {
+describe('EventBindingTest', () => {
   let calls: { type: 'on' | 'off'; name: string; handler: Handler }[];
   let boundHandlers: Record<string, Handler>;
 
@@ -39,8 +38,8 @@ UnitTest.test('Event binding test', () => {
   const dummyLookupProp: any = <K extends keyof IAllProps>(_key: K) => Fun.die('not implemented');
 
   // dummy functions for handlers
-  const focusHandler = () => {};
-  const blurHandler = () => {};
+  const focusHandler = Fun.noop;
+  const blurHandler = Fun.noop;
 
   // check no handlers
   calls = [];
@@ -80,5 +79,4 @@ UnitTest.test('Event binding test', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   configHandlers2(dummyLookupProp, on, off, adapter, { onFocus: focusHandler, onBlur: blurHandler }, { onFocus: focusHandler }, boundHandlers);
   check({ Blur: 'off' }, [ 'onFocus' ]);
-
 });

--- a/src/test/ts/browser/LoadTinyTest.ts
+++ b/src/test/ts/browser/LoadTinyTest.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Assertions } from '@ephox/agar';
 import { describe, it } from '@ephox/bedrock-client';
 import { Global } from '@ephox/katamari';
@@ -12,7 +13,7 @@ const assertTinymceVersion = (version: Version) => {
 describe('LoadTinyTest', () => {
   VERSIONS.forEach((version) => {
     it(`Should be able to load local version (${version}) of TinyMCE using the tinymceScriptSrc prop`, async () => {
-      using _ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
+      using _ = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
       assertTinymceVersion(version);
     });
   });
@@ -20,7 +21,7 @@ describe('LoadTinyTest', () => {
   CLOUD_VERSIONS.forEach((version) => {
     it(`Should be able to load TinyMCE from Cloud (${version})`, async () => {
       const apiKey = 'a-fake-api-key';
-      using _ctx = await render({ apiKey, cloudChannel: version });
+      using _ = await render({ apiKey, cloudChannel: version });
       assertTinymceVersion(version);
       Assertions.assertEq(
         'TinyMCE should have been loaded from Cloud',
@@ -30,7 +31,7 @@ describe('LoadTinyTest', () => {
     });
 
     it(`Should be able to load TinyMCE (${version}) in hybrid`, async () => {
-      using _ctx = await render({
+      using _ = await render({
         tinymceScriptSrc: [
           `/project/node_modules/tinymce-${version}/tinymce.min.js`,
           `https://cdn.tiny.cloud/1/${VALID_API_KEY}/tinymce/${version}/cloud-plugins.min.js?tinydrive=${version}`

--- a/src/test/ts/browser/LoadTinyTest.ts
+++ b/src/test/ts/browser/LoadTinyTest.ts
@@ -1,87 +1,53 @@
-import { Chain, Log, Pipeline, Assertions } from '@ephox/agar';
-import { UnitTest } from '@ephox/bedrock-client';
-import { Arr, Strings, Global } from '@ephox/katamari';
-import { SelectorFilter, Attribute, SugarElement, Remove } from '@ephox/sugar';
+import { Assertions } from '@ephox/agar';
+import { describe, it } from '@ephox/bedrock-client';
+import { Global } from '@ephox/katamari';
 
-import { ScriptLoader } from '../../../main/ts/ScriptLoader2';
-import { cRemove, cRender } from '../alien/Loader';
-import { VERSIONS, CLOUD_VERSIONS, type Version } from '../alien/TestHelpers';
+import { CLOUD_VERSIONS, VALID_API_KEY, VERSIONS, type Version } from '../alien/TestHelpers';
+import { render } from '../alien/Loader';
 
-const apiKey = 'qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc';
-UnitTest.asynctest('LoadTinyTest', (success, failure) => {
-  const cDeleteTinymce = Chain.op(() => {
-    ScriptLoader.reinitialize();
+const assertTinymceVersion = (version: Version) => {
+  Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
+};
 
-    delete Global.tinymce;
-    delete Global.tinyMCE;
-    const hasTinymceUri = (attrName: string) => (elm: SugarElement<Element>) =>
-      Attribute.getOpt(elm, attrName).exists((src) => Strings.contains(src, 'tinymce'));
-
-    const elements = Arr.flatten([
-      Arr.filter(SelectorFilter.all('script'), hasTinymceUri('src')),
-      Arr.filter(SelectorFilter.all('link'), hasTinymceUri('href')),
-    ]);
-
-    Arr.each(elements, Remove.remove);
+describe('LoadTinyTest', () => {
+  VERSIONS.forEach((version) => {
+    it(`Should be able to load local version (${version}) of TinyMCE using the tinymceScriptSrc prop`, async () => {
+      using _ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
+      assertTinymceVersion(version);
+    });
   });
 
-  const cAssertTinymceVersion = (version: Version) => Chain.op(() => {
-    Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
-  });
+  CLOUD_VERSIONS.forEach((version) => {
+    it(`Should be able to load TinyMCE from Cloud (${version})`, async () => {
+      const apiKey = 'a-fake-api-key';
+      using _ctx = await render({ apiKey, cloudChannel: version });
+      assertTinymceVersion(version);
+      Assertions.assertEq(
+        'TinyMCE should have been loaded from Cloud',
+        `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}`,
+        Global.tinymce.baseURI.source
+      );
+    });
 
-  Pipeline.async({}, [
-    Log.chainsAsStep('Should be able to load local version of TinyMCE using the tinymceScriptSrc prop', '', [
-      cDeleteTinymce,
-
-      ...VERSIONS.flatMap((version) => [
-        cRender({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js` }),
-        cAssertTinymceVersion(version),
-        cRemove,
-        cDeleteTinymce,
-      ]),
-    ]),
-
-    Log.chainsAsStep('Should be able to load TinyMCE from Cloud', '',
-      CLOUD_VERSIONS.flatMap((version) => [
-        cRender({ apiKey: 'a-fake-api-key', cloudChannel: version }),
-        cAssertTinymceVersion(version),
-        Chain.op(() => {
-          Assertions.assertEq(
-            'TinyMCE should have been loaded from Cloud',
-            `https://cdn.tiny.cloud/1/a-fake-api-key/tinymce/${version}`,
-            Global.tinymce.baseURI.source
-          );
-        }),
-        cRemove,
-        cDeleteTinymce,
-      ])
-    ),
-
-    Log.chainsAsStep('Should be able to load TinyMCE in hybrid', '',
-      CLOUD_VERSIONS.flatMap((version) => [
-        cRender({ tinymceScriptSrc: [
+    it(`Should be able to load TinyMCE (${version}) in hybrid`, async () => {
+      using _ctx = await render({
+        tinymceScriptSrc: [
           `/project/node_modules/tinymce-${version}/tinymce.min.js`,
-          `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}/cloud-plugins.min.js?tinydrive=${version}`
-        ], plugins: [ 'tinydrive' ] }),
-        cAssertTinymceVersion(version),
-        Chain.op(() => {
-          Assertions.assertEq(
-            'TinyMCE should have been loaded locally',
-            `/project/node_modules/tinymce-${version}`,
-            Global.tinymce.baseURI.path
-          );
-        }),
-        Chain.op(() => {
-          Assertions.assertEq(
-            'The tinydrive plugin should have defaults for the cloud',
-            `https://cdn.tiny.cloud/1/${apiKey}/tinymce-plugins/tinydrive/${version}/plugin.min.js`,
-            (Global.tinymce.defaultOptions || Global.tinymce.defaultSettings)?.custom_plugin_urls?.tinydrive
-          );
-        }),
-        cRemove,
-        cDeleteTinymce,
-        Chain.wait(1000),
-      ])
-    )
-  ], success, failure);
+          `https://cdn.tiny.cloud/1/${VALID_API_KEY}/tinymce/${version}/cloud-plugins.min.js?tinydrive=${version}`
+        ],
+        plugins: [ 'tinydrive' ]
+      });
+      assertTinymceVersion(version);
+      Assertions.assertEq(
+        'TinyMCE should have been loaded locally',
+        `/project/node_modules/tinymce-${version}`,
+        Global.tinymce.baseURI.path
+      );
+      Assertions.assertEq(
+        'The tinydrive plugin should have defaults for the cloud',
+        `https://cdn.tiny.cloud/1/${VALID_API_KEY}/tinymce-plugins/tinydrive/${version}/plugin.min.js`,
+        (Global.tinymce.defaultOptions || Global.tinymce.defaultSettings)?.custom_plugin_urls?.tinydrive
+      );
+    });
+  });
 });

--- a/src/test/ts/browser/LoadTinyTest.ts
+++ b/src/test/ts/browser/LoadTinyTest.ts
@@ -3,45 +3,45 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Global } from '@ephox/katamari';
 
 import { CLOUD_VERSIONS, VALID_API_KEY, VERSIONS, type Version } from '../alien/TestHelpers';
-import { render, ReactEditorContext } from '../alien/Loader';
+import { render } from '../alien/Loader';
 
-const assertTinymceVersion = (ctx: ReactEditorContext, version: Version) => {
-  Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, ctx.majorVersion);
+const assertTinymceVersion = (version: Version) => {
+  Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
 };
 
 describe('LoadTinyTest', () => {
   VERSIONS.forEach((version) => {
     it(`Should be able to load local version (${version}) of TinyMCE using the tinymceScriptSrc prop`, async () => {
-      using ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
-      assertTinymceVersion(ctx, version);
+      using _ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
+      assertTinymceVersion(version);
     });
   });
 
   CLOUD_VERSIONS.forEach((version) => {
     it(`Should be able to load TinyMCE from Cloud (${version})`, async () => {
       const apiKey = 'a-fake-api-key';
-      using ctx = await render({ apiKey, cloudChannel: version });
-      assertTinymceVersion(ctx, version);
+      using _ctx = await render({ apiKey, cloudChannel: version });
+      assertTinymceVersion(version);
       Assertions.assertEq(
         'TinyMCE should have been loaded from Cloud',
         `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}`,
-        ctx.editor.baseURI.source
+        Global.tinymce.baseURI.source
       );
     });
 
     it(`Should be able to load TinyMCE (${version}) in hybrid`, async () => {
-      using ctx = await render({
+      using _ctx = await render({
         tinymceScriptSrc: [
           `/project/node_modules/tinymce-${version}/tinymce.min.js`,
           `https://cdn.tiny.cloud/1/${VALID_API_KEY}/tinymce/${version}/cloud-plugins.min.js?tinydrive=${version}`
         ],
         plugins: [ 'tinydrive' ]
       });
-      assertTinymceVersion(ctx, version);
+      assertTinymceVersion(version);
       Assertions.assertEq(
         'TinyMCE should have been loaded locally',
         `/project/node_modules/tinymce-${version}`,
-        ctx.editor.baseURI.source
+        Global.tinymce.baseURI.path
       );
       Assertions.assertEq(
         'The tinydrive plugin should have defaults for the cloud',

--- a/src/test/ts/browser/LoadTinyTest.ts
+++ b/src/test/ts/browser/LoadTinyTest.ts
@@ -3,45 +3,45 @@ import { describe, it } from '@ephox/bedrock-client';
 import { Global } from '@ephox/katamari';
 
 import { CLOUD_VERSIONS, VALID_API_KEY, VERSIONS, type Version } from '../alien/TestHelpers';
-import { render } from '../alien/Loader';
+import { render, ReactEditorContext } from '../alien/Loader';
 
-const assertTinymceVersion = (version: Version) => {
-  Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
+const assertTinymceVersion = (ctx: ReactEditorContext, version: Version) => {
+  Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, ctx.majorVersion);
 };
 
 describe('LoadTinyTest', () => {
   VERSIONS.forEach((version) => {
     it(`Should be able to load local version (${version}) of TinyMCE using the tinymceScriptSrc prop`, async () => {
-      using _ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
-      assertTinymceVersion(version);
+      using ctx = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });
+      assertTinymceVersion(ctx, version);
     });
   });
 
   CLOUD_VERSIONS.forEach((version) => {
     it(`Should be able to load TinyMCE from Cloud (${version})`, async () => {
       const apiKey = 'a-fake-api-key';
-      using _ctx = await render({ apiKey, cloudChannel: version });
-      assertTinymceVersion(version);
+      using ctx = await render({ apiKey, cloudChannel: version });
+      assertTinymceVersion(ctx, version);
       Assertions.assertEq(
         'TinyMCE should have been loaded from Cloud',
         `https://cdn.tiny.cloud/1/${apiKey}/tinymce/${version}`,
-        Global.tinymce.baseURI.source
+        ctx.editor.baseURI.source
       );
     });
 
     it(`Should be able to load TinyMCE (${version}) in hybrid`, async () => {
-      using _ctx = await render({
+      using ctx = await render({
         tinymceScriptSrc: [
           `/project/node_modules/tinymce-${version}/tinymce.min.js`,
           `https://cdn.tiny.cloud/1/${VALID_API_KEY}/tinymce/${version}/cloud-plugins.min.js?tinydrive=${version}`
         ],
         plugins: [ 'tinydrive' ]
       });
-      assertTinymceVersion(version);
+      assertTinymceVersion(ctx, version);
       Assertions.assertEq(
         'TinyMCE should have been loaded locally',
         `/project/node_modules/tinymce-${version}`,
-        Global.tinymce.baseURI.path
+        ctx.editor.baseURI.source
       );
       Assertions.assertEq(
         'The tinydrive plugin should have defaults for the cloud',

--- a/src/test/ts/browser/LoadTinyTest.ts
+++ b/src/test/ts/browser/LoadTinyTest.ts
@@ -1,16 +1,38 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Assertions } from '@ephox/agar';
-import { describe, it } from '@ephox/bedrock-client';
-import { Global } from '@ephox/katamari';
+import { beforeEach, describe, it } from '@ephox/bedrock-client';
+import { Arr, Global, Strings } from '@ephox/katamari';
 
 import { CLOUD_VERSIONS, VALID_API_KEY, VERSIONS, type Version } from '../alien/TestHelpers';
 import { render } from '../alien/Loader';
+import { ScriptLoader } from 'src/main/ts/ScriptLoader2';
+import { Attribute, Remove, SelectorFilter, SugarElement } from '@ephox/sugar';
 
 const assertTinymceVersion = (version: Version) => {
   Assertions.assertEq(`Loaded version of TinyMCE should be ${version}`, version, Global.tinymce.majorVersion);
 };
 
+export const deleteTinymce = () => {
+  ScriptLoader.reinitialize();
+
+  delete Global.tinymce;
+  delete Global.tinyMCE;
+  const hasTinymceUri = (attrName: string) => (elm: SugarElement<Element>) =>
+    Attribute.getOpt(elm, attrName).exists((src) => Strings.contains(src, 'tinymce'));
+
+  const elements = Arr.flatten([
+    Arr.filter(SelectorFilter.all('script'), hasTinymceUri('src')),
+    Arr.filter(SelectorFilter.all('link'), hasTinymceUri('href')),
+  ]);
+
+  Arr.each(elements, Remove.remove);
+};
+
 describe('LoadTinyTest', () => {
+  beforeEach(() => {
+    deleteTinymce();
+  });
+
   VERSIONS.forEach((version) => {
     it(`Should be able to load local version (${version}) of TinyMCE using the tinymceScriptSrc prop`, async () => {
       using _ = await render({ tinymceScriptSrc: `/project/node_modules/tinymce-${version}/tinymce.min.js`, licenseKey: 'gpl' });


### PR DESCRIPTION
Jira: [INT-3297](https://ephocks.atlassian.net/browse/INT-3297)

Changes:
- Replaced all agar chain usage with newer BDD style of testing or just async await in general.
- `Loader.tsx` now exports a `render` function that returns a `ReactEditorContext`. This implements `Disposable`, which simplifies creating safe tests that cleanup editor instances and associated React DOM nodes.
- `Loader.tsx` also exports a `withVersion` function that passes a `RenderWithVersion` function to a callback. This function is similar to the exported `render` function but with some props omited:
```ts 
Omit<IAllProps, 'cloudChannel' | 'tinymceScriptSrc'>
```
- Added an eslint override for the tests to support the `using` keyword.

[INT-3297]: https://ephocks.atlassian.net/browse/INT-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ