### PR TITLE
INT-3308_2: Put back support for any unknown key to be assigned as an init prop

### DIFF
--- a/src/main/ts/components/Editor.tsx
+++ b/src/main/ts/components/Editor.tsx
@@ -14,14 +14,14 @@ interface DoNotUse<T extends string> {
 
 type OmittedInitProps = 'selector' | 'target' | 'readonly' | 'license_key';
 
-export type EditorOptions = Parameters<TinyMCE['init']>[0];
+type EditorOptions = Parameters<TinyMCE['init']>[0];
 
 export type InitOptions = Omit<OmitStringIndexSignature<EditorOptions>, OmittedInitProps> & {
   selector?: DoNotUse<'selector prop is handled internally by the component'>;
   target?: DoNotUse<'target prop is handled internally by the component'>;
   readonly?: DoNotUse<'readonly prop is overridden by the component, use the `disabled` prop instead'>;
   license_key?: DoNotUse<'license_key prop is overridden by the integration, use the `licenseKey` prop instead'>;
-};
+} & { [key: string]: unknown };
 
 export type Version = `${'4' | '5' | '6' | '7'}${'' | '-dev' | '-testing' | `.${number}` | `.${number}.${number}`}`;
 

--- a/src/test/ts/browser/EditorInitTest.ts
+++ b/src/test/ts/browser/EditorInitTest.ts
@@ -85,6 +85,28 @@ describe('EditorInitTest', () => {
           }
         });
       });
+
+      it('Assigning other unknown props to the editor is allowed', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        using _ = await render({
+          init: {
+            mergetags_list: [{
+              title: 'Client',
+              menu: [
+                {
+                  value: 'Client.LastCallDate',
+                  title: 'Call date'
+                },
+                {
+                  value: 'Client.Name',
+                  title: 'Client name'
+                }
+              ]
+            }],
+            something_else: 'value'
+          }
+        });
+      });
     })
   );
 });


### PR DESCRIPTION
[INT-3308](https://ephocks.atlassian.net/browse/INT-3308)

Changes:
- This allows unknown init props to be assigned again, as it's needed for props that are added by plugins. These plugin init props aren't typed in the base editor options.
- Removed the export for EditorOptions, as it wasn't exported before the previous PR.
- Added a test for this typing behaviour.

[INT-3308]: https://ephocks.atlassian.net/browse/INT-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ