### PR TITLE
Hotfix: Added explicit build step before publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,5 +20,9 @@ mixedBeehiveFlow(
         echo "Skipping as is not latest release"
       }
     }
+  },
+  preparePublish:{
+    yarnInstall()
+    sh "yarn build"
   }
 )


### PR DESCRIPTION
Now that `mixedBeehiveFlow` is used in CI instead of `beehiveFlowBuild`, there's no default build step. So this just adds a build step before publishing.