### PR TITLE
Prepare for 6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.0.0 - 2025-02-21
+
 ### Fixed
 - Updated dependencies. #INT-3324
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "typescript": "~5.5.3",
     "vite": "^5.3.3"
   },
-  "version": "6.0.0-rc",
+  "version": "6.0.0",
   "name": "@tinymce/tinymce-react"
 }


### PR DESCRIPTION
Description of changes:
- Added the `6.0.0` heading to the changelog
- Removed `rc` in the version