### PR TITLE
Move @tinymce/miniature from devDependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "Ephox Corporation DBA Tiny Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
+    "@tinymce/miniature": "^6.0.0",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {
@@ -58,7 +59,6 @@
     "@storybook/react-vite": "^8.6.4",
     "@tinymce/beehive-flow": "^0.19.0",
     "@tinymce/eslint-plugin": "^2.4.0",
-    "@tinymce/miniature": "^6.0.0",
     "@types/node": "^22.13.10",
     "@types/prop-types": "^15.7.14",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
First of all, sorry if this is not the way to contribute.

This PR fixes https://github.com/tinymce/tinymce-react/issues/590

https://github.com/tinymce/tinymce-react/pull/588 added an import from @tinymce/miniature code in src/main/ts/Utils.ts.